### PR TITLE
Removed the extra \cite expression.

### DIFF
--- a/source/filter-helper.ts
+++ b/source/filter-helper.ts
@@ -19,7 +19,6 @@ const defaultFilters: Filter[] = [
   {pattern: /(\\bibliographystyle{)(.*?)(})/g, newValue: ''},
   {pattern: /(\\caption{)(.*?)(})/g, newValue: '$2'},
   {pattern: '\\centering', newValue: ''},
-  {pattern: /( \\cite(p|al\[]|alp\[])?{)(.*?)}([ .,])/g, newValue: '$4'},
   {pattern: /\\cite(p|al\[]|alp\[])?{(.*?)}/g, newValue: ''},
   {pattern: /(\\citestyle{)(.*?)(})/g, newValue: ''},
   {pattern: /(\\date{)(.*?)(})/g, newValue: '$2'},


### PR DESCRIPTION
As mentioned in #70 there is a bug with the ´\cite´ regular expression. With this PR I removed the one that has is more complex and also selects the ",." and then subtitutes it.
[Here is an visualization of the wrong expression.](https://www.debuggex.com/r/hvqJQ0RaKVM6FT_6).  


Hope you can merge this into master in time to tomorrows release.

